### PR TITLE
pass app updateEntries func from child comps

### DIFF
--- a/frame/src/components/EntryCreate/EntryCreate.jsx
+++ b/frame/src/components/EntryCreate/EntryCreate.jsx
@@ -204,6 +204,7 @@ const EntryCreateForm = Form.create()(
 );
 
 export class EntryCreate extends Component {
+
   state = {
     visible: false,
   };
@@ -215,7 +216,11 @@ export class EntryCreate extends Component {
   handleCancel = () => {
     const form = this.formRef.props.form;
     form.resetFields();
-    this.setState({ visible: false, entryTags: [], entryTitle: 'New entry' });
+    this.setState({ visible: false });
+  }
+
+  refreshMenuList = () => {
+    this.setState({visible: false});
   }
 
   handleCreate = () => {
@@ -226,20 +231,30 @@ export class EntryCreate extends Component {
       if (err) {
         return;
       }
+      console.log("FORM VALUES: ", values);
       const library = getState("library");
       const m_Library = openDB(library);
       getFromDB(m_Library, "entries").then(function(result) {
         m_Entries = result;
         m_Entries.unshift(values); // Add entry to top of tree
-        saveToDB(m_Library, "entries", m_Entries);
-        form.resetFields();
-        message.success("Created new library entry!");
+        saveToDB(m_Library, "entries", m_Entries).then(function(result) {
+          form.resetFields();
+          message.success("Created new library entry!");
+          console.log("CREATED NEW LIB ENTRY");
+          // _this.setState({visible: false});
+          _this.props.updateEntriesMethod();
+          _this.refreshMenuList();
+          // _this.forceUpdate();
+        })
       }).catch(function(err) {
-        message.fail("Failed to create library entry: ", err);
+        alert(err);
+        form.resetFields();
+        message.success("Failed to create new library entry!");
+        _this.refreshMenuList();
+        // _this.setState({visible: false});
       });
     });
-    this.setState({ visible: false, entryTags: [], entryTitle: 'New entry' });
-    return m_Entries;
+    this.forceUpdate();
   }
 
   saveFormRef = (formRef) => {

--- a/frame/src/components/MainMenu/MainMenu.jsx
+++ b/frame/src/components/MainMenu/MainMenu.jsx
@@ -95,7 +95,6 @@ export default class MainMenu extends Component {
     // For entry create modal
   }
 
-
   async getEntries(Library, key) {
     let Entries = [];
     await getFromDB(Library, key).then(function(result) {
@@ -142,7 +141,7 @@ export default class MainMenu extends Component {
     saveToDB(Library, "entries", this.state.treeData);
     console.log("Saved tree data to Library: ", this.state.treeData);
     message.success('Saved library changes!');
-    this.forceUpdate();
+    this.props.updateEntriesMethod();
   }
 
   // JSONEditor funcs
@@ -340,7 +339,7 @@ export default class MainMenu extends Component {
               <Divider />
                 <div className="entriesEditorButtonsContainer">
                   <div className="mainEntriesButtonsWrapper">
-                    <EntryCreate/>
+                    <EntryCreate updateEntriesMethod={this.props.updateEntriesMethod}/>
                     <div className="primaryGhostButton"
                       style={{display: 'inline'}}>
                       <Tooltip title="Switch explorer view">

--- a/frame/src/utils/save-db.js
+++ b/frame/src/utils/save-db.js
@@ -4,13 +4,15 @@
 /* eslint no-console: 0 */
 
 export default function saveToDB(store, key, value) {
-    store.setItem(key, value).then(function (result) {
-        // console.log("Saved to store ", key, ':', store);
-        // console.log(result);
-        return result;
-    }).catch(function(err) {
-        // console.log(err);
-        return null;
-    });
+    // store.setItem(key, value).then(function (result) {
+    //     // console.log("Saved to store ", key, ':', store);
+    //     // console.log(result);
+    //     return result;
+    // }).catch(function(err) {
+    //     // console.log(err);
+    //     return null;
+    // });
+    const res = store.setItem(key, value);
+    return res;
 }
   


### PR DESCRIPTION
NOTE: actually instead of using localForage, the main menu and other child comps of the app rely on the props that are passed (from the main app comp).

this commit adds an updateEntries func that is called by the child comps which sets the main app state. 